### PR TITLE
Image fixes ++

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![DroneCI](https://ci.abakus.no/api/badges/webkom/lego-editor/status.svg?branch=master)
 
-> Work-in-progress editor for [lego-webapp](https://github.com/webkom/lego-webapp) written with [Slate.js](https://docs.slatejs.org)
+> Work-in-progress editor for [lego-webapp](https://github.com/webkom/lego-webapp) written with [Slate.js](https://docs.slatejs.org) ![npm (scoped)](https://img.shields.io/npm/v/@webkom/lego-editor?style=flat-square)
 
 <img src="https://i.imgur.com/6zIQhYm.png" />
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,7 +9,12 @@ import './App.css';
 const App = () => (
   <div>
     <h1>Lego editor</h1>
-    <Editor placeholder="Testing lego editor" />
+    <Editor
+      placeholder="Testing lego editor"
+      imageUpload={file =>
+        new Promise(resolve => resolve(URL.createObjectURL(file)))
+      }
+    />
   </div>
 );
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/classnames": "^2.2.8",
     "@types/is-hotkey": "^0.1.1",
     "@types/is-url": "^1.2.28",
+    "@types/lodash": "^4.14.137",
     "@types/react": "^16.8.14",
     "@types/react-image-crop": "^6.0.2",
     "@types/slate": "^0.47.1",

--- a/src/Editor.css
+++ b/src/Editor.css
@@ -51,9 +51,6 @@
   margin-block-start: 1em;
   margin-block-end: 1em;
 }
-/*
- * TODO: Use psudo-selectors for 3n, 2n, n-th... list element
- */
 
 ._legoEditor_ul_list > ul {
   list-style: circle;
@@ -84,10 +81,7 @@
 }
 
 ._legoEditor_figure {
-  background-color: #fcfcfc;
   padding: 20px 10px 0;
-  border: 0.5px solid #f4f4f4;
-  border-radius: 2px;
   margin: auto;
   display: flex;
   flex-direction: column;

--- a/src/components/ImageBlock.tsx
+++ b/src/components/ImageBlock.tsx
@@ -4,8 +4,6 @@ import { RenderAttributes } from 'slate-react';
 
 interface Props {
   editor: Editor;
-  file: Blob;
-  imageUrl: string;
   src: string;
   isFocused: boolean;
   attributes: RenderAttributes;
@@ -13,24 +11,11 @@ interface Props {
 }
 
 export default class ImageBlock extends React.Component<Props> {
-  componentDidMount(): void {
-    //if (this.props.file) {
-    //this.props.uploadFile({ file: this.props.file, isPublic: true }).then(({ meta }) => {
-    //});
-    //}
-    const { editor, file, imageUrl } = this.props;
-    editor.setNodeByKey(this.props.node.key, {
-      data: { imageUrl, file /*, fileKey: meta.fileToken.split(":")[0]*/ },
-      type: 'image'
-    });
-  }
-
   render(): React.ReactNode {
-    const { imageUrl, src, attributes, isFocused } = this.props;
+    const { src, attributes, isFocused } = this.props;
     return (
       <img
-        onLoad={() => URL.revokeObjectURL(imageUrl)}
-        src={src ? src : imageUrl}
+        src={src}
         alt="Failed to load image..."
         className={isFocused ? '_legoEditor_imgSelected' : '_legoEditor_img'}
         {...attributes}

--- a/src/components/ImageUpload.css
+++ b/src/components/ImageUpload.css
@@ -1,8 +1,8 @@
 ._legoEditor_imageUploader_wrapper {
-  z-index: 10000;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
   position: fixed;
   min-width: 100%;
   min-height: 100%;
@@ -13,29 +13,137 @@
 
 ._legoEditor_imageUploader_root {
   opacity: 1;
-  background-color: #ddd;
+  background-color: #fff;
   width: 60%;
+  z-index: 15;
   top: 10%;
   left: 20%;
-  margin: auto;
-  margin-top: 30px;
-  margin-bottom: 30px;
+  margin: 0 30px;
   padding: 15px;
   border-radius: 5px;
-  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 ._legoEditor_imageUploader_dropZone {
   width: 80%;
-  height: 200px;
+  height: 100%;
   border: 2px dashed rgba(0, 0, 0, 0.2);
   border-radius: 4px;
   margin: auto;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #909090;
+  flex: 1 1 auto;
+}
+
+._legoEditor_imageUploader_crop_wrapper {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  min-height: 400px;
 }
 
 ._legoEditor_imageUploader_crop_container {
-  border: 3px solid #b5b5b5;
-  background-color: #bbb;
+  margin: 5px;
+  padding: 2px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background:url(
+  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJ0lEQVQoU2PcvXv3fwY0cPbsWXQhBsahoLCjowPDM8bGxpieGQIKAezGK+59+t2AAAAAAElFTkSuQmCC
+  ) repeat;
+}
+
+._legoEditor_imageUploader_buttonContainer {
+  display: flex;
+  justify-content: space-evenly;
+  margin: 30px;
+  flex: 0 1 auto;
+}
+
+._legoEditor_imageUploader_button  {
+  border-radius: 4px;
+  background-color: #fff;
+  padding: 9px 18px;
+  cursor: pointer;
+  font-family: inherit;
+  background: none;
+  border: 0;
+  box-sizing: border-box;
+  box-shadow: inset 0 0 0 1px #c7c7c7;
+  position: relative;
+  vertical-align: middle;
+}
+
+._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+  box-sizing: inherit;
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+
+._legoEditor_imageUploader_button:hover {
+  transition: color 0.2s;
+}
+
+._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+  border: 2px solid transparent;
+  width: 0;
+  height: 0;
+ }
+
+._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+  top: 0;
+  left: 0;
+}
+
+._legoEditor_imageUploader_applyButton:hover {
+  color: #0a6640;
+}
+
+._legoEditor_imageUploader_cancelButton:hover {
+  color: #c0392b;
+}
+
+._legoEditor_imageUploader_button:hover::before, ._legoEditor_imageUploader_button:hover::after {
+  width: 100%;
+  height: 100%;
+}
+
+._legoEditor_imageUploader_applyButton:hover::before {
+  border-top-color: #0a6640;
+  border-right-color:#0a6640;
+  transition:
+    height 0.2s ease-out 0.2s,
+    width 0.2s ease-out;
+}
+
+._legoEditor_imageUploader_cancelButton:hover::before {
+  border-top-color: #c0392b;
+  border-right-color: #c0392b;
+  transition:
+    width 0.2s ease-out,
+    height 0.2s ease-out 0.2s;
+}
+
+._legoEditor_imageUploader_applyButton:hover::after {
+  border-bottom-color: #0a6640;
+  border-left-color: #0a6640;
+  transition:
+    height 0.2s ease-out,
+    width 0.2s ease-out 0.2s;
+}
+
+._legoEditor_imageUploader_cancelButton:hover::after {
+  border-bottom-color: #c0392b;
+  border-left-color: #c0392b;
+  transition:
+    height 0.2s ease-out,
+    width 0.2s ease-out 0.2s;
 }

--- a/src/components/ImageUpload.css
+++ b/src/components/ImageUpload.css
@@ -53,9 +53,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background:url(
+  background: url(
   data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJ0lEQVQoU2PcvXv3fwY0cPbsWXQhBsahoLCjowPDM8bGxpieGQIKAezGK+59+t2AAAAAAElFTkSuQmCC
-  ) repeat;
+  )
+    repeat;
 }
 
 ._legoEditor_imageUploader_buttonContainer {
@@ -65,7 +66,7 @@
   flex: 0 1 auto;
 }
 
-._legoEditor_imageUploader_button  {
+._legoEditor_imageUploader_button {
   border-radius: 4px;
   background-color: #fff;
   padding: 9px 18px;
@@ -79,7 +80,8 @@
   vertical-align: middle;
 }
 
-._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+._legoEditor_imageUploader_button::before,
+._legoEditor_imageUploader_button::after {
   box-sizing: inherit;
   content: '';
   position: absolute;
@@ -87,18 +89,19 @@
   height: 100%;
 }
 
-
 ._legoEditor_imageUploader_button:hover {
   transition: color 0.2s;
 }
 
-._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+._legoEditor_imageUploader_button::before,
+._legoEditor_imageUploader_button::after {
   border: 2px solid transparent;
   width: 0;
   height: 0;
- }
+}
 
-._legoEditor_imageUploader_button::before, ._legoEditor_imageUploader_button::after {
+._legoEditor_imageUploader_button::before,
+._legoEditor_imageUploader_button::after {
   top: 0;
   left: 0;
 }
@@ -111,39 +114,32 @@
   color: #c0392b;
 }
 
-._legoEditor_imageUploader_button:hover::before, ._legoEditor_imageUploader_button:hover::after {
+._legoEditor_imageUploader_button:hover::before,
+._legoEditor_imageUploader_button:hover::after {
   width: 100%;
   height: 100%;
 }
 
 ._legoEditor_imageUploader_applyButton:hover::before {
   border-top-color: #0a6640;
-  border-right-color:#0a6640;
-  transition:
-    height 0.2s ease-out 0.2s,
-    width 0.2s ease-out;
+  border-right-color: #0a6640;
+  transition: height 0.2s ease-out 0.2s, width 0.2s ease-out;
 }
 
 ._legoEditor_imageUploader_cancelButton:hover::before {
   border-top-color: #c0392b;
   border-right-color: #c0392b;
-  transition:
-    width 0.2s ease-out,
-    height 0.2s ease-out 0.2s;
+  transition: width 0.2s ease-out, height 0.2s ease-out 0.2s;
 }
 
 ._legoEditor_imageUploader_applyButton:hover::after {
   border-bottom-color: #0a6640;
   border-left-color: #0a6640;
-  transition:
-    height 0.2s ease-out,
-    width 0.2s ease-out 0.2s;
+  transition: height 0.2s ease-out, width 0.2s ease-out 0.2s;
 }
 
 ._legoEditor_imageUploader_cancelButton:hover::after {
   border-bottom-color: #c0392b;
   border-left-color: #c0392b;
-  transition:
-    height 0.2s ease-out,
-    width 0.2s ease-out 0.2s;
+  transition: height 0.2s ease-out, width 0.2s ease-out 0.2s;
 }

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -44,7 +44,6 @@ const ImageDrop: React.StatelessComponent<ImageDropProps> = (
   );
 };
 
-// TODO Allow for several images in one component
 export default class ImageUpload extends React.Component<Props, State> {
   readonly state: State = {
     hasImage: false

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useDropzone } from 'react-dropzone';
 import ReactCrop, { Crop } from 'react-image-crop';
 import cropImage from '../utils/cropImage';
+import cx from 'classnames';
 
 interface Props {
   uploadFunction?: (image: Blob) => void;
@@ -94,33 +95,43 @@ export default class ImageUpload extends React.Component<Props, State> {
     return (
       <div className="_legoEditor_imageUploader_wrapper">
         <div className="_legoEditor_imageUploader_root">
-          {currentImage ? (
-            <div className="_legoEditor_imageUploader_crop_container">
-              <ReactCrop
-                src={currentImage.url}
-                onChange={this.handleCrop}
-                onImageLoaded={this.onImageLoaded}
-                crop={crop}
-              />
-            </div>
-          ) : (
-            <div>
+          <div className="_legoEditor_imageUploader_crop_wrapper">
+            {currentImage ? (
+              <div className="_legoEditor_imageUploader_crop_container">
+                <ReactCrop
+                  src={currentImage.url}
+                  onChange={this.handleCrop}
+                  onImageLoaded={this.onImageLoaded}
+                  crop={crop}
+                />
+              </div>
+            ) : (
               <ImageDrop onDrop={this.onDrop} />
-            </div>
-          )}
-          <button
-            className="_legoEditor_imageUploader_applyButton"
-            onClick={this.submitImage}
-          >
-            Apply
-          </button>
+            )}
+          </div>
+          <div className="_legoEditor_imageUploader_buttonContainer">
+            <button
+              className={cx(
+                '_legoEditor_imageUploader_applyButton',
+                '_legoEditor_imageUploader_button'
+              )}
+              onClick={this.submitImage}
+              type="button"
+            >
+              Apply
+            </button>
 
-          <button
-            className="_legoEditor_imageUploader_cancelButton"
-            onClick={this.cancel}
-          >
-            Cancel
-          </button>
+            <button
+              className={cx(
+                '_legoEditor_imageUploader_cancelButton',
+                '_legoEditor_imageUploader_button'
+              )}
+              onClick={this.cancel}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -277,8 +277,8 @@ export default class Toolbar extends React.Component<
           <i className="fa fa-code" />
         </ToolbarButton>
         <ToolbarButton
-          active={this.checkActiveBlock('code-block')}
-          handler={e => this.toggleBlock(e, 'code-block')}
+          active={this.checkActiveBlock('code_block')}
+          handler={e => this.toggleBlock(e, 'code_block')}
         >
           <i className="fa fa-file-code-o" />
         </ToolbarButton>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -50,15 +50,16 @@ class LinkInput extends React.Component<LinkInputProps, LinkInputState> {
   };
 
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // TODO move this to onInput
-    //if (e.key == "Enter") {
-    //this.submit(e);
-    //return;
-    //}
     this.setState({ value: e.currentTarget.value });
   };
 
-  submit = (e: React.FocusEvent | React.MouseEvent) => {
+  onKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key == 'Enter') {
+      this.submit(e);
+    }
+  };
+
+  submit = (e: React.FocusEvent | React.KeyboardEvent | React.MouseEvent) => {
     e.preventDefault();
     const { value } = this.state;
     this.props.toggleLinkInput();
@@ -67,12 +68,6 @@ class LinkInput extends React.Component<LinkInputProps, LinkInputState> {
     }
     this.props.updateLink({ url: value });
   };
-
-  componentDidMount(): void {
-    if (this.input.current) {
-      this.input.current.focus();
-    }
-  }
 
   render(): React.ReactNode {
     const validUrl = isUrl(this.state.value);
@@ -83,6 +78,7 @@ class LinkInput extends React.Component<LinkInputProps, LinkInputState> {
           placeholder="Link"
           ref={this.input}
           onChange={this.onChange}
+          onKeyDown={this.onKeyPress}
           value={this.state.value}
         />
         <button disabled={!validUrl} onClick={this.submit}>
@@ -211,7 +207,7 @@ export default class Toolbar extends React.Component<
     const { editor } = this.props;
 
     if (!this.checkActiveInline('link')) {
-      return undefined;
+      return;
     }
 
     // @ts-ignore - previous line already checks that inline is not undefined
@@ -237,28 +233,6 @@ export default class Toolbar extends React.Component<
   onSubmit(image: Blob): void {
     const { editor } = this.props;
     editor.command('insertImage', image);
-  }
-
-  // TODO see if this actually works...
-  shouldComponentUpdate(
-    nextProps: ToolbarProps,
-    nextState: ToolbarState
-  ): boolean {
-    /*
-     * Re-rendering every time the 'Editor' changes causes a lot of lag.
-     * It should only update if the current selections block type or marks changes
-     */
-
-    const currentValue = this.props.editor.value;
-    const newValue = nextProps.editor.value;
-
-    const marksChanged = currentValue.activeMarks != newValue.activeMarks;
-    const blockChanged = currentValue.blocks != newValue.blocks;
-    const inlineChanged = currentValue.inlines != newValue.inlines;
-
-    return (
-      marksChanged || blockChanged || inlineChanged || this.state != nextState
-    );
   }
 
   render(): React.ReactNode {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ import images from './plugins/images';
 import markdownShortcuts from './plugins/markdown';
 import { html } from './serializer';
 import schema from './schema';
+import * as _ from 'lodash';
 
 interface Props {
   value: string;
@@ -172,7 +173,9 @@ export default class Editor extends React.Component<Props, State> {
 
   onChange = ({ value: value }: { value: Slate.Value }): void => {
     this.setState({ editorValue: value });
-    this.props.onChange && this.props.onChange(html.serialize(value));
+    // Debounce onchange function to improve performance
+    this.props.onChange &&
+      _.debounce(this.props.onChange, 250)(html.serialize(value));
   };
 
   onKeyDown = (
@@ -327,7 +330,6 @@ export default class Editor extends React.Component<Props, State> {
     editor: Slate.Editor,
     next: Next
   ): Promise<any> {
-    event.preventDefault();
     await next();
     if (this.props.onFocus) {
       await this.props.onFocus();
@@ -339,7 +341,6 @@ export default class Editor extends React.Component<Props, State> {
     editor: Slate.Editor,
     next: Next
   ): Promise<any> {
-    event.preventDefault();
     await next();
     if (this.props.onBlur) {
       await this.props.onBlur();

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,7 +5,6 @@ import { SchemaProperties } from 'slate';
 // Schema for the editor value
 // This can handle normalizing and rules for the value
 // If there are any rules for how the value should be, add them here
-// TODO consider normalizing code blocks, (no marks, not inside lists?)
 const schema: SchemaProperties = {
   document: {
     last: { type: 'paragraph' },
@@ -107,7 +106,7 @@ const schema: SchemaProperties = {
             { type: 'paragraph' },
             { type: 'h1' },
             { type: 'h4' },
-            { type: 'code' }
+            { type: 'code_block' }
           ]
         }
       ]
@@ -122,10 +121,13 @@ const schema: SchemaProperties = {
             { type: 'paragraph' },
             { type: 'h1' },
             { type: 'h4' },
-            { type: 'code' }
+            { type: 'code_block' }
           ]
         }
       ]
+    },
+    code_block: {
+      marks: []
     }
   },
   inlines: {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -96,6 +96,36 @@ const schema: SchemaProperties = {
           }
         }
       }
+    },
+    ul_list: {
+      nodes: [
+        {
+          match: [
+            { type: 'list_item' },
+            { type: 'ul_list' },
+            { type: 'ol_list' },
+            { type: 'paragraph' },
+            { type: 'h1' },
+            { type: 'h4' },
+            { type: 'code' }
+          ]
+        }
+      ]
+    },
+    ol_list: {
+      nodes: [
+        {
+          match: [
+            { type: 'list_item' },
+            { type: 'ul_list' },
+            { type: 'ol_list' },
+            { type: 'paragraph' },
+            { type: 'h1' },
+            { type: 'h4' },
+            { type: 'code' }
+          ]
+        }
+      ]
     }
   },
   inlines: {

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -15,7 +15,7 @@ const BLOCK_TAGS: TAGS = {
   ul: 'ul_list',
   ol: 'ol_list',
   li: 'list_item',
-  pre: 'code-block',
+  pre: 'code_block',
   figure: 'figure',
   img: 'image',
   figcaption: 'image_caption'
@@ -97,7 +97,7 @@ const rules: Rule[] = [
             return <ol>{children}</ol>;
           case 'list_item':
             return <li>{children}</li>;
-          case 'code-block':
+          case 'code_block':
             return (
               <pre>
                 <code>{children}</code>

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,13 +720,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/immutable@^3.8.7":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@types/immutable/-/immutable-3.8.7.tgz#536d33d30f3f3d9a6d4642a219419fd82af633fb"
-  integrity sha1-U20z0w8/PZptRkKiGUGf2Cr2M/s=
-  dependencies:
-    immutable "*"
-
 "@types/is-hotkey@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@types/is-hotkey/-/is-hotkey-0.1.1.tgz#802e294c2a02f26fbcbe8639c77ef05e38cfdc8c"
@@ -741,6 +734,11 @@
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
+"@types/lodash@^4.14.137":
+  version "4.14.137"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.137.tgz#8a4804937dc6462274ffcc088df8f14fc1b368e2"
+  integrity sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -3147,7 +3145,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immutable@*, immutable@^3.8.2:
+immutable@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=


### PR DESCRIPTION
Fixed some image related stuff, and removed some todos :100: 
- Added schema rules for `ul_list`,  `ol_list` and `code_block` block types.
- Finish image uploading logic. the `images` plugin now takes the following as its option: 
```
options: {
  uploadFunction: (file: Blob) => Promise<string>
}
```
where the string from the promise is the src to to uploaded image. The options is passed down from the `Editors` `imageUpload` prop.

- Finalize imageuploader styling:
![image](https://user-images.githubusercontent.com/42850232/63714692-9b468e80-c842-11e9-866a-05ec06d2e01a.png)