### PR TITLE
Increase compatibility for images

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -12,7 +12,7 @@ const App = () => (
     <Editor
       placeholder="Testing lego editor"
       imageUpload={file =>
-        new Promise(resolve => resolve(URL.createObjectURL(file)))
+        new Promise(resolve => resolve())
       }
     />
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-editor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A React editor written in TS with slate.js for lego-webapp",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -219,11 +219,11 @@ export default class Toolbar extends React.Component<
     this.setState({ insertingImage: true });
   }
 
-  insertImage(image: Blob): void {
+  insertImage(image: Blob, data?: Record<string, any>): void {
     const { editor } = this.props;
 
     this.setState({ insertingImage: false });
-    editor.command('insertImage', image);
+    editor.command('insertImage', image, data);
   }
 
   onClose(): void {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ interface Props {
   onFocus?: () => void;
   autoFocus?: boolean;
   placeholder?: string;
-  imageUpload: (file: Blob) => Promise<string>;
+  imageUpload: (file: Blob) => Promise<Record<string, any>>;
   plugins: Plugin[];
 }
 

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -105,14 +105,19 @@ const rules: Rule[] = [
             );
           case 'figure':
             return <figure>{children}</figure>;
-          case 'image':
+          case 'image': {
+            // For compatibility with https://github.com/webkom/lego
+            const data = obj.data.toJS();
+            const { fileKey } = data;
             return (
               <img
                 src={obj.data.get('src')}
-                data-file-key={obj.data.get('fileKey')}
+                data-file-key={fileKey}
+                {...data}
                 alt="Placeholder"
               />
             );
+          }
           case 'image_caption':
             return <figcaption>{children}</figcaption>;
         }

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -48,12 +48,20 @@ const rules: Rule[] = [
             };
           }
           case 'image': {
+            const fileKey = el.getAttribute('data-file-key');
+            const dataFromHtml = el.getAttributeNames().reduce(
+              (data: Record<string, any>, attrName: string) => ({
+                ...data,
+                attrName: el.getAttribute(attrName)
+              }),
+              {}
+            );
             return {
               object: 'block',
               type: type,
               data: {
-                src: el.getAttribute('src'),
-                fileKey: el.getAttribute('data-file-key')
+                ...dataFromHtml,
+                fileKey
               }
             };
           }


### PR DESCRIPTION
Adds a fallback for the image src when uploading, with a local objectURL.
The `uploadFunction` passed to the images plugin now needs to return a `Promise<Record<string, any>>`, that is, a promise with an object.