### PR TITLE
Allow editor to be server rendered & image fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,19 @@ The `<Editor />` component accepts the prop `plugins`, which takes an array of p
 
 ## Props
 
-| name          | Type                                  | Default | Description                                                                                                        |
-| ------------- | ------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `value`       | `string`                              |         | The editors value/default value                                                                                    |
-| `disabled`    | `Boolean`                             | `False` | Disables the ability to edit the content                                                                           |
-| `simple`      | `Boolean`                             | `False` | Removes the toolbar.                                                                                               |
-| `onChange`    | `string => void`                      |         | Handler called when the editor value changes. Takes the serialized value                                           |
-| `onBlur`      | `event => void`                       |         | Handler called on blur                                                                                             |
-| `onFocus`     | `event => void`                       |         | Handler called on focus                                                                                            |
-| `autoFocus`   | `Boolean`                             | `False` | Enables autoFocus                                                                                                  |
-| `placeholder` | `string`                              |         | A placeholder shown when the editor is empty                                                                       |
-| `imageUpload` | `Blob => Promise<Record<string,any>>` |         | A function for uploading images. Should contain `src` in the promise object.                                       |
-| `plugins`     | `(Editor => Editor)[]`                |         | An array of plugins to load. The first plugin will be applied first (the last one will override any other plugins) |
+| name          | Type                                  | Default | Description                                                                                                                                                                     |
+| ------------- | ------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`       | `string`                              |         | The editors value/default value                                                                                                                                                 |
+| `disabled`    | `Boolean`                             | `False` | Disables the ability to edit the content                                                                                                                                        |
+| `simple`      | `Boolean`                             | `False` | Removes the toolbar.                                                                                                                                                            |
+| `onChange`    | `string => void`                      |         | Handler called when the editor value changes. Takes the serialized value                                                                                                        |
+| `onBlur`      | `event => void`                       |         | Handler called on blur                                                                                                                                                          |
+| `onFocus`     | `event => void`                       |         | Handler called on focus                                                                                                                                                         |
+| `autoFocus`   | `Boolean`                             | `False` | Enables autoFocus                                                                                                                                                               |
+| `placeholder` | `string`                              |         | A placeholder shown when the editor is empty                                                                                                                                    |
+| `imageUpload` | `Blob => Promise<Record<string,any>>` |         | A function for uploading images. Should contain `src` in the promise object.                                                                                                    |
+| `plugins`     | `(Editor => Editor)[]`                |         | An array of plugins to load. The first plugin will be applied first (the last one will override any other plugins)                                                              |
+| `domParser`   | `string => HTMLDocument`              |         | Custom function that the deserializer will use to parse the input value to a HTML document. Can be useful for environments where the browser API is not available, like Node.js |
 
 > See type definitions for more detailed types
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -11,9 +11,10 @@ const App = () => (
     <h1>Lego editor</h1>
     <Editor
       placeholder="Testing lego editor"
-      imageUpload={file =>
-        new Promise(resolve => resolve())
-      }
+      imageUpload={file => new Promise(resolve => setTimeout(resolve, 1000))}
+      onChange={str => {
+        console.log(str);
+      }}
     />
   </div>
 );

--- a/src/Editor.css
+++ b/src/Editor.css
@@ -105,6 +105,8 @@
 }
 
 ._legoEditor_img {
+  min-width: 50px;
+  min-height: 50px;
   border: none;
 }
 

--- a/src/components/ImageBlock.tsx
+++ b/src/components/ImageBlock.tsx
@@ -1,22 +1,29 @@
 import * as React from 'react';
-import { RenderElementProps, useFocused } from 'slate-react';
+import { RenderElementProps, useSelected } from 'slate-react';
+import cx from 'classnames';
 
 interface Props extends RenderElementProps {
   src: string;
   children: any;
+  uploading?: boolean;
 }
 
 const ImageBlock = (props: Props): JSX.Element => {
-  const { src, children } = props;
+  // https://github.com/yannickcr/eslint-plugin-react/issues/2654
+  // eslint-disable-next-line react/prop-types
+  const { src, children, uploading, attributes } = props;
 
-  const isFocused = useFocused();
+  const isFocused = useSelected();
+  const baseClass = isFocused ? '_legoEditor_imgSelected' : '_legoEditor_img';
   return (
-    <div>
-      <img
-        src={src}
-        alt="Failed to load image..."
-        className={isFocused ? '_legoEditor_imgSelected' : '_legoEditor_img'}
-      />
+    <div {...attributes}>
+      <div contentEditable={false}>
+        <img
+          src={src}
+          alt="Failed to load image..."
+          className={cx(baseClass, uploading && '_legoEditor_imgUploading')}
+        />
+      </div>
       {children}
     </div>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Element, Editor, NodeEntry, Range, Node } from 'slate';
+import { Editor, NodeEntry, Range, Node } from 'slate';
 import { useSlate } from 'slate-react';
 import { LEditor, Marks, Elements, nodeType } from '../index';
 import ImageUpload from './ImageUpload';
@@ -194,12 +194,18 @@ const Toolbar = (): JSX.Element => {
 
   const openImageUploader = (e: React.PointerEvent): void => {
     e.preventDefault();
+    setLastSelection(editor.selection);
     setInsertingImage(true);
   };
 
   const insertImage = (image: Blob, data?: Record<string, any>): void => {
+    editor.exec({
+      type: 'insert_image',
+      file: image,
+      at: lastSelection,
+      ...data
+    });
     setInsertingImage(false);
-    editor.exec({ type: 'insert_image', file: image, ...data });
   };
 
   return (
@@ -211,10 +217,10 @@ const Toolbar = (): JSX.Element => {
         H1
       </ToolbarButton>
       <ToolbarButton
-        active={checkActiveElement('h4')}
-        handler={e => toggleBlock(e, 'h4')}
+        active={checkActiveElement('h3')}
+        handler={e => toggleBlock(e, 'h3')}
       >
-        H4
+        H3
       </ToolbarButton>
       <ToolbarButton
         active={checkActiveMark('bold')}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {
   RenderElementProps,
   RenderLeafProps
 } from 'slate-react';
-import { createEditor, Editor, Element, Node, Location } from 'slate';
+import { createEditor, Editor, Node, Location } from 'slate';
 import { withHistory } from 'slate-history';
 import isHotKey from 'is-hotkey';
 import Toolbar from './components/Toolbar';
@@ -35,6 +35,7 @@ interface Props {
   placeholder?: string;
   imageUpload: (file: Blob) => Promise<Record<string, any>>;
   plugins: ((editor: Editor) => Editor)[];
+  domParser: (value: string) => HTMLDocument;
 }
 
 export const DEFAULT_BLOCK = 'paragraph';
@@ -169,18 +170,19 @@ const renderElement = (props: RenderElementProps): JSX.Element => {
     }
     case 'image_caption':
       return (
-        <figcaption
-          className="_legoEditor_figcaption"
-          {...attributes}
-          placeholder={'Figure caption'}
-        >
+        <figcaption className="_legoEditor_figcaption" {...attributes}>
           {children}
         </figcaption>
       );
     // Inlines
     case 'link':
       return (
-        <a {...attributes} href={element.url}>
+        <a
+          {...attributes}
+          href={element.url}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
           {children}
         </a>
       );
@@ -246,7 +248,11 @@ const LegoEditor = (props: Props): JSX.Element => {
   );
 
   const [value, setValue] = useState(
-    props.value ? deserializeHtmlString(props.value) : initialValue
+    props.value
+      ? deserializeHtmlString(props.value, {
+          domParser: props.domParser
+        })
+      : initialValue
   );
 
   return (

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -135,7 +135,8 @@ export const deserialize = (
     return '\n';
   }
 
-  let children = Array.from(el.childNodes).map((n: ChildNode) =>
+  // This is flatmapped to make sure we have a situation where a child is an array.
+  let children = Array.from(el.childNodes).flatMap((n: ChildNode) =>
     deserialize(n as HTMLElement)
   ) as Node[];
 
@@ -205,11 +206,26 @@ export const deserialize = (
   return el.textContent;
 };
 
-export const deserializeHtmlString = (html: string): Node[] => {
-  const document: HTMLDocument = new DOMParser().parseFromString(
-    html,
-    'text/html'
-  );
+interface DeserializerOptions {
+  domParser?: (value: string) => HTMLDocument;
+}
+
+/**
+ * Deserialize a string of html to a html document in order to convert to the slate object model.
+ *
+ * Specify a `domParser` in `options` in order to use another parser than the one included in common
+ * browsers. (Required when running in node.js).
+ */
+export const deserializeHtmlString = (
+  html: string,
+  options?: DeserializerOptions
+): Node[] => {
+  let document: HTMLDocument;
+  if (options?.domParser) {
+    document = options.domParser(html);
+  } else {
+    document = new DOMParser().parseFromString(html, 'text/html');
+  }
 
   return deserialize(document.body) as Node[];
 };

--- a/src/utils/cropImage.ts
+++ b/src/utils/cropImage.ts
@@ -25,6 +25,7 @@ const cropImage = (
   if (!ctx) {
     return new Promise(resolve => resolve());
   }
+  ctx.fillStyle = '#FFFFFF';
   ctx.drawImage(
     image,
     (crop.x || 0) * scaleX,
@@ -45,7 +46,7 @@ const cropImage = (
       } else {
         reject();
       }
-    }, 'image/jpeg');
+    }, 'image/png');
   });
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,65 +1,27 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": [
-      "ES2016",
-      "DOM"
-    ] /* Specify library files to be included in the compilation. */,
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true /* Generates corresponding '.map' file. */,
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist" /* Redirect output structure to the directory. */,
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "incremental": true,                   /* Enable incremental compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    "downlevelIteration": true /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */,
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["ES2019", "DOM"],
+    "allowJs": false,
+    "checkJs": false,
+    "jsx": "react",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "downlevelIteration": true,
 
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": false,
 
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "esModuleInterop": true,
+    "inlineSourceMap": true,
+    "inlineSources": true
   }
 }


### PR DESCRIPTION
- Adds an option to use a custom domParser for serialization. This allows the editor to be server-side rendered when it is disabled.
- Adds a location option to the `insert_image` command. Allows the image to be inserted at a specified location and fixes an issue where images were inserted on top of each other and removed in some cases.
- Crops images to png to retain transparency

Also fixes a small issue where the deserializer crashed because a child was not of the correct type on on very rare case. (Still don't know what caused this)