### PR TITLE
Fix bad normalizing in lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint 'src/**/*.{js,ts,tsx}' && prettier 'src/**' --list-different",
     "prettier": "prettier 'src/**' --write",
     "dev:build": "webpack --mode development",
-    "dev": "webpack-dev-server --config ./example/webpack/webpack.config.js --open --mode development"
+    "dev": "webpack-dev-server --config ./example/webpack/webpack.config.js --mode development"
   },
   "repository": {
     "type": "git",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import {
 import { serialize, deserializeHtmlString } from './serializer';
 import { debounce } from 'lodash';
 import { compose } from 'lodash/fp';
+import cx from 'classnames';
 
 interface Props {
   value: string;
@@ -259,7 +260,7 @@ const LegoEditor = (props: Props): JSX.Element => {
     <div
       className={
         props.disabled || props.simple
-          ? '_legoEditor_disabled'
+          ? cx('_legoEditor_root', '_legoEditor_disabled')
           : '_legoEditor_root'
       }
     >


### PR DESCRIPTION
Fixes #217 
Fixes #218 

Removes the normalizing rule for merging lists, as it was causing a lot of problems, both in the editor state, but also with the history.

Fixes an issue where some styles were missing when the `disabled` prop is set.