### PR TITLE
Use sourse ts files with webpack in the dev app directly

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import Editor from '../../dist/index.js';
-import '../../dist/Editor.css';
-import '../../dist/components/Toolbar.css';
-import '../../dist/components/ImageUpload.css';
+import Editor from '../../src/index';
+import '../../src/Editor.css';
+import '../../src/components/Toolbar.css';
+import '../../src/components/ImageUpload.css';
 import 'react-image-crop/dist/ReactCrop.css';
 import './App.css';
 
@@ -11,8 +11,10 @@ const App = () => (
     <h1>Lego editor</h1>
     <Editor
       placeholder="Testing lego editor"
-      imageUpload={file => new Promise(resolve => setTimeout(resolve, 1000))}
-      onChange={str => {
+      imageUpload={(file) =>
+        new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+      onChange={(str) => {
         console.log(str);
       }}
     />

--- a/example/webpack/webpack.config.js
+++ b/example/webpack/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = () => {
     output: {
       path: path.resolve(__dirname, '../build'),
       filename: '[name]-[hash].js',
-      sourceMapFilename: '[file].map'
+      sourceMapFilename: '[file].map',
     },
     entry: path.resolve(__dirname, '../src/index.js'),
     module: {
@@ -15,43 +15,48 @@ module.exports = () => {
         {
           test: /\.js?$/,
           use: 'source-map-loader',
-          enforce: 'pre'
+          enforce: 'pre',
         },
         {
           test: /\.js?$/,
           use: {
-            loader: 'babel-loader'
+            loader: 'babel-loader',
           },
-          exclude: /node_modules/
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
         },
         {
           test: /\.html$/,
           use: [
             {
-              loader: 'html-loader'
-            }
-          ]
+              loader: 'html-loader',
+            },
+          ],
         },
         {
           test: /\.css$/,
-          use: ['style-loader', 'css-loader']
-        }
-      ]
+          use: ['style-loader', 'css-loader'],
+        },
+      ],
     },
     resolve: {
-      extensions: ['*', '.js', '.css']
+      extensions: ['*', '.js', '.ts', '.tsx', '.css'],
     },
     plugins: [
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, '../src/index.html'),
-        filname: './index.html'
+        filname: './index.html',
       }),
-      new webpack.HotModuleReplacementPlugin()
+      new webpack.HotModuleReplacementPlugin(),
     ],
     devServer: {
       contentBase: path.resolve(__dirname, '../dist'),
-      hot: true
+      hot: true,
     },
-    devtool: 'source-map'
+    devtool: 'inline-source-map',
   };
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dom": "^16.8.6",
     "source-map-loader": "^1.0.1",
     "style-loader": "^1.0.1",
+    "ts-loader": "^8.0.6",
     "typescript": "^4.0.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "downlevelIteration": true,
@@ -21,7 +21,6 @@
     "noImplicitReturns": false,
 
     "esModuleInterop": true,
-    "inlineSourceMap": true,
     "inlineSources": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,7 +1619,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1805,7 +1805,7 @@ caniuse-lite@^1.0.30001088:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz#ff7766332f60e80fea4903f30d360622e5551850"
   integrity sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg==
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2526,7 +2526,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
   integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
@@ -3964,7 +3964,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -4104,6 +4104,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -4657,7 +4665,7 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -5299,7 +5307,7 @@ semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -5907,6 +5915,17 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+ts-loader@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.6.tgz#8f47d203ef8fc95826a292a09f97a02bf1f57565"
+  integrity sha512-c8XkRbhKxFLbiIwZR7FBGWDq0MIz/QSpx3CGpj0abJxD5YVX8oDhQkJLeGbXUPRIlaX4Ajmr77fOiFVZ3gSU7g==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"


### PR DESCRIPTION
Currently, the example app uses the compiled bundle in `/dist`, as well as the css files in `/dist`. This is a bit inconvenient when developing, because we have to compile with `tsc` continuously.

By using `ts-loader`, we avoid having both webpack and tsc watching our files. So deving should be a lot better.