### PR TITLE
prevent https-prepend on a mail-url

### DIFF
--- a/src/utils/isUrl.ts
+++ b/src/utils/isUrl.ts
@@ -8,7 +8,7 @@ const onlyHostnameRe = new RegExp('^' + hostnameRe.source);
 const isUrl = (url: string): boolean => urlRe.test(url) || mailRe.test(url);
 
 export const prependHttps = (hostname: string): string => {
-  if (onlyHostnameRe.test(hostname)) {
+  if (onlyHostnameRe.test(hostname) && !mailRe.test(hostname)) {
     return 'https://' + hostname;
   }
   return hostname;


### PR DESCRIPTION
The `prependHttps`-method preemptively applied `https://` to any url missing it, including `mailto:`-urls. 
An test is added to the function to prevent this.
