### PR TITLE
Change dependabot schedule time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "04:00"
+      time: "10:00"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: slate-history


### PR DESCRIPTION
Due to db lock at 6 am, Drone does not accept webhook deliveries, causing the CI to never run.