### PR TITLE
Fix typescript types in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepublish": "yarn ts && yarn build",
-    "build": "vite build",
+    "build": "vite build && yarn build:types",
+    "build:types": "tsc -d --emitDeclarationOnly",
     "dev": "vite",
     "preview": "vite preview",
     "test": "vitest run",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "files": ["src/index.tsx"],
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
@@ -9,7 +10,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "rootDir": ".",
+    "rootDir": "./src",
+    "outDir": "./dist",
     "downlevelIteration": true,
 
     "strict": true,


### PR DESCRIPTION
Vite appearently doesn't export typescript type declarations when building in library mode, so we need a plugin, [vite-plugin-dts](https://www.npmjs.com/package/vite-plugin-dts), to do it. 