### PR TITLE
Fix Example Code Snippet In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
   const YourComponent = () => (
     <div>
-      <Editor placeholder="Let the words flow!">
+      <Editor placeholder="Let the words flow!"/>
     </div>
   )
   ```


### PR DESCRIPTION
The example given in the README is missing a slash at the end of the tag. This PR fixes it.