### PR TITLE
Fix Invisible Text In Link Input When Using Dark Mode

### DIFF
--- a/src/components/LinkInput.css
+++ b/src/components/LinkInput.css
@@ -17,7 +17,6 @@
 
 ._legoEditor_linkInput_label input {
   flex: 1 1 auto;
-  color: var(--color-black);
 }
 ._legoEditor_linkInput_label span {
   flex: 0 1 auto;


### PR DESCRIPTION
The text color to the input box was set to the variable _--color-black_, which equates to black when using light mode and white when using dark mode. The problem is that the color of the input box is always white, regardless of the mode, and therefore you end up with a white input box with white text when using dark mode. By removing the color property entirely in the css file, the text color will be set to its default value (which is black).