### PR TITLE
Enable text strikethrough in editor

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -182,6 +182,12 @@ const Toolbar = (): JSX.Element => {
         <i className="fa fa-underline" />
       </ToolbarButton>
       <ToolbarButton
+        active={checkActiveMark('strikethrough')}
+        handler={(e) => toggleMark(e, 'strikethrough')}
+      >
+        <i className="fa fa-strikethrough" />
+      </ToolbarButton>
+      <ToolbarButton
         active={checkActiveMark('code')}
         handler={(e) => toggleMark(e, 'code')}
       >

--- a/src/custom-types.ts
+++ b/src/custom-types.ts
@@ -6,7 +6,13 @@ import { PluginsEditor, ListEditor, LinkEditor, ImageEditor } from './plugins';
 
 export type Next = () => unknown;
 
-export const MARKS = ['bold', 'italic', 'code', 'underline'] as const;
+export const MARKS = [
+  'bold',
+  'italic',
+  'code',
+  'underline',
+  'strikethrough',
+] as const;
 export type Mark = typeof MARKS[number];
 export type Elements =
   | 'h1'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -105,6 +105,9 @@ const renderLeaf = (props: RenderLeafProps): JSX.Element => {
   if (leaf.code) {
     children = <code>{children}</code>;
   }
+  if (leaf.strikethrough) {
+    children = <s>{children}</s>;
+  }
   return <span {...props.attributes}>{children}</span>;
 };
 
@@ -213,6 +216,9 @@ const LegoEditor = (props: Props): JSX.Element => {
     } else if (isHotKey('mod+u')(e)) {
       e.preventDefault();
       editor.toggleMark('underline');
+    } else if (isHotKey('shift+alt+5')(e)) {
+      e.preventDefault();
+      editor.toggleMark('strikethrough');
     } else {
       editor.keyHandler({ event: e });
     }

--- a/src/serializer.test.ts
+++ b/src/serializer.test.ts
@@ -107,13 +107,14 @@ describe('serializer', () => {
         italic: true,
         underline: true,
         code: true,
+        strikethrough: true,
       })
     );
 
     const serialized = serialize(element);
 
     expect(serialized).toEqual(
-      '<p>Paragraph <strong>with </strong><code><u><em property="italic"><strong>marks</strong></em></u></code></p>'
+      '<p>Paragraph <strong>with </strong><s><code><u><em property="italic"><strong>marks</strong></em></u></code></s></p>'
     );
   });
 
@@ -329,7 +330,7 @@ describe('deserializeHtmlString', () => {
 
   it('deserializes text with multiple marks', () => {
     const deserialized = deserializeHtmlString(
-      '<p>this <em>text <strong>is <u>marked <code>up!</code></u></strong></em></p>'
+      '<p>this <em>text <strong>is <s><u>marked <code>up!</code></u></s></strong></em></p>'
     ) as TextElement[];
 
     expect(deserialized).toHaveLength(1);
@@ -352,6 +353,7 @@ describe('deserializeHtmlString', () => {
       italic: true,
       bold: true,
       underline: true,
+      strikethrough: true,
     });
 
     expect(paragraph.children[4].text).toBe('up!');
@@ -359,6 +361,7 @@ describe('deserializeHtmlString', () => {
       italic: true,
       bold: true,
       underline: true,
+      strikethrough: true,
       code: true,
     });
   });

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -31,9 +31,10 @@ const MARK_TAGS = {
   strong: 'bold',
   u: 'underline',
   code: 'code',
+  s: 'strikethrough',
 } as const;
 
-type MarkNode = 'em' | 'i' | 'strong' | 'u' | 'code';
+type MarkNode = 'em' | 'i' | 'strong' | 'u' | 'code' | 's';
 
 const serializeData = (object: Record<string, unknown>): string =>
   Object.keys(object)
@@ -64,6 +65,9 @@ export const serialize = (node: SlateNode): string => {
     }
     if (node.code) {
       text = `<code>${text}</code>`;
+    }
+    if (node.strikethrough) {
+      text = `<s>${text}</s>`;
     }
     return text;
   }


### PR DESCRIPTION
# Description
As requested in [this](https://github.com/webkom/lego-editor/issues/739) issue it is now possible to strikethrough text. One can either use the hotkey `alt+shift+5` as used by Google Spreadsheets, or manually press the icon.

# Result
**Before**
![image](https://user-images.githubusercontent.com/43182025/221584480-7f0e8176-ac7f-4ef8-8589-990e7c04b0aa.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/221584390-f8134b6b-120e-438e-89f4-b0239fbc35e4.png)


# Testing

- [x] I have thoroughly tested my changes.

The changes have been tested manually both with light and dark mode. As well, the feature is added to the serializer and deserializer tests.

---

Resolves #739 and [ABA-308](https://linear.app/abakus-webkom/issue/ABA-308/support-text-strikethrough-in-lego-editor)