### PR TITLE
Add word-break to editor paragraphs

### DIFF
--- a/src/Editor.css
+++ b/src/Editor.css
@@ -94,6 +94,7 @@
   margin-block-start: 1em;
   margin-block-end: 1em;
   line-height: 24px;
+  word-break: break-word;
 }
 
 ._legoEditor_figure {


### PR DESCRIPTION
Prevents long words and paragraphs to overflow the editor.

Tested by adding the selector in prod, and worked out pretty well.