### PR TITLE
Include react-router-dom as an external dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-editor",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A React editor written in TS with slate.js for lego-webapp",
   "type": "module",
   "main": "./dist/lego-editor.umd.cjs",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
     sourcemap: true,
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react-router-dom'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
It is the reason the [tests are failing in lego-webapp](https://ci.webkom.dev/webkom/lego-webapp/9375/1/12).