### PR TITLE
Fix funny compression (ABA-827)

### DIFF
--- a/src/utils/cropImage.ts
+++ b/src/utils/cropImage.ts
@@ -16,8 +16,8 @@ const cropImage = (
   const canvas = document.createElement('canvas');
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
-  canvas.width = crop.width;
-  canvas.height = crop.height;
+  canvas.width = crop.width * scaleX;
+  canvas.height = crop.height * scaleY;
   const ctx = canvas.getContext('2d');
 
   // canvas.getContext(<identifier>) returns null if
@@ -30,12 +30,12 @@ const cropImage = (
     image,
     (crop.x || 0) * scaleX,
     (crop.y || 0) * scaleY,
-    crop.width * scaleX,
-    crop.height * scaleY,
+    canvas.width,
+    canvas.height,
     0,
     0,
-    crop.width,
-    crop.height,
+    canvas.width,
+    canvas.height,
   );
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
For some reason, image size was determined by the crop viewport :upside_down_face: 

This means cropping a large image on a small screen would create a small image (and in theory vice versa).

This will likely resolve (ABA-827), as inserting an image is no longer determined by viewport size, but original image size.

This also means uploading a large image makes it large (assuming AWS has no compression, i has no checked).

Before:

![Screenshot from 2024-04-14 18-36-44](https://github.com/webkom/lego-editor/assets/42469466/f9012836-5e95-4a5a-a227-6eaf71757814)

After:
![Screenshot from 2024-04-14 18-37-51](https://github.com/webkom/lego-editor/assets/42469466/ca3d3213-b60a-419c-b31c-2afe91414a7f)

